### PR TITLE
Remove duplicated renv/sandbox line in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,4 @@ docs/
 po/*~
 
 # renv sandbox needed for renv version 0.16.0
-renv/sandbox # OPTIONAL
-renv/sandbox
 renv/sandbox


### PR DESCRIPTION
There seems to be a problem with the `# OPTIONAL` comment. This PR fixes the detection of the `renv/sandbox` line and avoid adding it over and over again.